### PR TITLE
Update install.sh location back to Habitat Git repo.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM alpine:3.3
 MAINTAINER Brian L. Scott <Brian@Bscott.io>
 RUN apk add --no-cache vim nano wget ca-certificates gnupg
 RUN cd /tmp \
-  && wget https://gist.githubusercontent.com/bscott/c14ee24a3feafd2f5234af8950c8b420/raw/hab-install.sh \
-  && sh hab-install.sh \
-  && rm -f hab-install.sh \
+  && wget https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh \
+  && sh install.sh \
+  && rm -f install.sh \
   && echo "hab:x:42:42:root:/:/bin/sh" >> /etc/passwd \
   && echo "hab:x:42:hab" >> /etc/group
 WORKDIR /src


### PR DESCRIPTION
Now that habitat-sh/habitat#982 is merged, we should be good use the `install.sh` from the Habitat repo, yay!
