### PR TITLE
Reduce image size & introduce build-arg for CD release pipelines

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM alpine:3.4
 MAINTAINER Brian L. Scott <Brian@Bscott.io>
+ARG HAB_VERSION=
 RUN set -ex \
   && apk add --no-cache --virtual .build-deps \
     wget \
@@ -7,8 +8,8 @@ RUN set -ex \
     gnupg \
   \
   && cd /tmp \
-  && wget https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh \
-  && sh install.sh \
+  && wget https://gist.githubusercontent.com/fnichol/55501687ecdcd0f7218f0416673ca896/raw/12594be4d572d4befdee0b22130619b9301c3d19/install.sh \
+  && sh install.sh ${HAB_VERSION:-} \
   && rm -f install.sh \
   && apk del .build-deps \
   \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,19 @@
-FROM alpine:3.3
+FROM alpine:3.4
 MAINTAINER Brian L. Scott <Brian@Bscott.io>
-RUN apk add --no-cache vim nano wget ca-certificates gnupg
-RUN cd /tmp \
+RUN set -ex \
+  && apk add --no-cache --virtual .build-deps \
+    wget \
+    ca-certificates \
+    gnupg \
+  \
+  && cd /tmp \
   && wget https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh \
   && sh install.sh \
   && rm -f install.sh \
+  && apk del .build-deps \
+  \
   && echo "hab:x:42:42:root:/:/bin/sh" >> /etc/passwd \
   && echo "hab:x:42:hab" >> /etc/group
 WORKDIR /src
 VOLUME ["/src"]
-CMD ["hab"]
+CMD ["/bin/hab"]


### PR DESCRIPTION
This changeset shrinks the Docker image layers and total install size by almost 70% by removing the build-time Alpine packages (which a consumer of this image could add depending on their needs).

This changeset also introduces a Dockerfile build arg called `HAB_VERSION` which
can be used to set a specific version or version/release of hab from the
Depot.

The default build behavior is still in tack:

```
docker build -t bscott/habitat .
```

But a specific version can be baked in with:

```
docker build -t bscott/habitat --build-arg HAB_VERSION=0.8.0/20160729175817 .
```

This change should help to produce a tag-per-release model, tracking new
`core/hab` releases to the Depot.
