### PR TITLE
Add ncurses-terminfo-base package to image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN set -ex \
   && rm -f install.sh \
   && apk del .build-deps \
   \
+  && apk add --no-cache ncurses-terminfo-base \
+  \
   && echo "hab:x:42:42:root:/:/bin/sh" >> /etc/passwd \
   && echo "hab:x:42:hab" >> /etc/group
 WORKDIR /src


### PR DESCRIPTION
This change adds a very minimal terminfo database to the image via
Alpine's `ncurses-terminfo-base` package.

As of [Habitat 0.9.3](https://forums.habitat.sh/t/habitat-0-9-3-released/213), the `hab` binary will use the `$TERM`
environment variable to query the system's local terminfo database for
determining if ansi coloring is supported. In the lack of a database
entry, `hab` will fall back to uncolored output (as it should). Clearly,
we want some pretty colors by default if we can manage it, and this is
the bare minimum to make it happen. It adds roughly 92kB to the
extracted disk usage so I don't think we're doing anyone a disservice.

Signed-off-by: Fletcher Nichol fnichol@nichol.ca
