### PR TITLE
Upgrade to Alpine 3.5 base image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
-FROM alpine:3.4
+FROM alpine:3.5
 MAINTAINER Brian L. Scott <Brian@Bscott.io>
 ARG HAB_VERSION=
 RUN set -ex \
   && apk add --no-cache --virtual .build-deps \
-    wget \
     ca-certificates \
     gnupg \
+    libressl \
+    wget \
   \
   && cd /tmp \
   && wget https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh \


### PR DESCRIPTION
Note that there is an issue with properly determining TLS certificates
from api.bintray.com when using this image's `wget` and `openssl`
packages. However, the `wget` and `libressl` combination does work--who
knew?

References docker-library/official-images#2773

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>