### PR TITLE
Add `{{pkg_version}}`-only tag to image.

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -11,20 +11,26 @@ if [ -z "${HAB_VERSION:-}" ]; then
 fi
 
 image="bscott/habitat"
-tag="${image}:$(echo "$HAB_VERSION" | tr '/' '-')"
+tag1="$(echo "$HAB_VERSION" | tr '/' '-')"
+tag2="$(echo "$HAB_VERSION" | cut -d '/' -f 1)"
+tag3="latest"
 
-banner "Building $tag for hab version $HAB_VERSION"
-docker build -t "$tag" --build-arg "HAB_VERSION=$HAB_VERSION" .
-image_id="$(docker images -q "$tag")"
-docker tag "$image_id" "${image}:latest"
+banner "Building $image for hab version $HAB_VERSION"
+docker build \
+  --tag "$image:$tag1" \
+  --tag "$image:$tag2" \
+  --tag "$image:$tag3" \
+  --build-arg "HAB_VERSION=$HAB_VERSION" \
+  .
+image_id="$(docker images -q "$tag1")"
 info "Build complete."
 
 info
-banner "Docker image built: $tag ($image_id)"
+banner "Docker image built: $image ($image_id)"
 info
 info "Try it out with:"
 info
-info "    docker run --rm -ti --privileged -v \$(pwd):/src bscott/habitat sh"
+info "    docker run --rm -ti --privileged -v \$(pwd):/src $image sh"
 info
 
 exit 0

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -21,22 +21,27 @@ if [ -z "${DOCKER_PASSWORD:-}" ]; then
 fi
 
 image="bscott/habitat"
-tag="${image}:$(echo "$HAB_VERSION" | tr '/' '-')"
+tag1="$(echo "$HAB_VERSION" | tr '/' '-')"
+tag2="$(echo "$HAB_VERSION" | cut -d '/' -f 1)"
+tag3="latest"
 
 banner "Logging in to Docker Hub..."
 docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
 info "Login success."
 
-banner "Pushing $tag"
-docker push "$tag"
-info "Pushing $tag complete."
-banner "Pushing ${image}:latest"
-docker push "${image}:latest"
-info "Pushing ${image}:latest complete."
+banner "Pushing $image:$tag1"
+docker push "$image:$tag1"
+info "Pushing $image:$tag1 complete."
+banner "Pushing $image:$tag2"
+docker push "$image:$tag2"
+info "Pushing $image:$tag2 complete."
+banner "Pushing $image:$tag3"
+docker push "$image:$tag3"
+info "Pushing $image:$tag3 complete."
 
 info "Cleaning up"
 rm -rf "$HOME/.docker/config.json"
 
-banner "Deploy $tag complete."
+banner "Deploy $image complete."
 
 exit 0


### PR DESCRIPTION
This change sets 3 tags on the Docker image. Given a `HAB_VERSION` of
`0.30.2/20170822232349`, then following tags would be created:

* bscott/habitat:0.30.2-20170822232349
* bscott/habitat:0.30.2
* bscott/habitat:latest

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>