### PR TITLE
April 2018 Updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex \
   && cd /tmp \
   && wget https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh \
   && sh install.sh -v ${HAB_VERSION:-} \
-  && rm -rf install.sh /hab/cache \
+  && rm -rf install.sh /hab/cache /root/.wget-hsts /root/.gnupg \
   && apk del .build-deps \
   \
   && apk add --no-cache ncurses-terminfo-base \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.7
 MAINTAINER Brian L. Scott <Brian@Bscott.io>
 ARG HAB_VERSION=
 RUN set -ex \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -30,7 +30,7 @@ banner "Docker image built: $image ($image_id)"
 info
 info "Try it out with:"
 info
-info "    docker run --rm -ti --privileged -v \$(pwd):/src $image sh"
+info "    docker run --rm -ti --privileged -v \$(pwd):/src $image:$tag1 sh"
 info
 
 exit 0


### PR DESCRIPTION
There are several small updates here:

* Upgrade to Alpine Linux 3.7
* Delete `.wget-hsts` and `.gnupg/` from root's home directory
* [build.sh] Print out the full tag when displaying the example test line